### PR TITLE
Migrate print as a function instead of a statement

### DIFF
--- a/liam2/process.py
+++ b/liam2/process.py
@@ -168,7 +168,7 @@ class ProcessGroup(Process):
                     utils.timed(v.run_guarded, context)
                 else:
                     v.run_guarded(context)
-                    #            print "done."
+                    #
                 context.simulation.start_console(context)
         finally:
             if config.autodump is not None:

--- a/liam2/simulation.py
+++ b/liam2/simulation.py
@@ -592,11 +592,11 @@ class Simulation(object):
             else:
                 for entity in entities:
                     entity.store_period_data(period)
-#            print " - compressing period data"
+#            print(" - compressing period data")
 #            for entity in entities:
-#                print "  *", entity.name, "...",
+#                print("  *", entity.name, "..."),
 #                for level in range(1, 10, 2):
-#                    print "   %d:" % level,
+#                    print("   %d:" % level),
 #                    timed(entity.compress_period_data, level)
             period_objects[period] = sum(len(entity.array)
                                          for entity in entities)

--- a/liam2/tests/unit/test_groupby.py
+++ b/liam2/tests/unit/test_groupby.py
@@ -10,7 +10,7 @@ def assertResultEq(d1, d2):
         v1, v2 = d1[k], d2[k]
         assert np.array_equal(v1, v2), \
                "%s value differs. we get: %s\nexpected: %s" % (k, v1, v2)
-    print ".",
+    print("."),
 
 
 def assertGroupByEq(arrays, filter, result):

--- a/tools/align_txt2csv.py
+++ b/tools/align_txt2csv.py
@@ -1,7 +1,7 @@
 import sys
 import csv
 from itertools import izip
-from os import path 
+from os import path
 
 def rename_var(name):
     if name.startswith('p_'):
@@ -18,7 +18,7 @@ def rename_var(name):
 
 def load_txt_align(input_path, inverted=False):
     start_col = 2 + int(not inverted)
-             
+
     with open(input_path, "rb") as f:
         lines = list(csv.reader(f, delimiter='\t'))
 
@@ -26,12 +26,12 @@ def load_txt_align(input_path, inverted=False):
     var1 = lines[15][1]
     assert lines[16][0] == 'name2'
     var2 = lines[16][1]
-    
+
     assert lines[17][0] == 'nCategory1'
     ncateg1 = int(lines[17][1])
     assert lines[18][0] == 'nCategory2'
     ncateg2 = int(lines[18][1])
-    
+
     assert lines[21][0] == 'predict'
     # skip the 21 first lines
     lines = lines[22:]
@@ -39,26 +39,26 @@ def load_txt_align(input_path, inverted=False):
     colvals = lines.pop(0)
     assert colvals.pop(0) == 'colval'
     assert colvals.pop(0) == ''
-    
+
     # discard any extra data at the end of the line
     colvals = [eval(val) for val in colvals[:ncateg2*2:2] if val]
     assert len(colvals) == ncateg2
-    
+
     # skip next two lines
     assert lines.pop(0)[0] == 'colvars'
     assert lines.pop(0)[:2] == ['rowval', 'rowvars']
-    
+
     rowvals = [eval(line[1]) for line in lines[:ncateg1]]
     assert len(rowvals) == ncateg1
-    
-    # discard var name and row vals at the start of each line and any extra 
+
+    # discard var name and row vals at the start of each line and any extra
     # data at their end
-    data = [[eval(val) for val in line[start_col:start_col+2*ncateg2:2] if val] 
+    data = [[eval(val) for val in line[start_col:start_col+2*ncateg2:2] if val]
             for line in lines[:ncateg1]]
     return (var1, var2), (colvals, rowvals), data
 
 def save_csv_align(output_path, variables, possible_values, data):
-    
+
     colvals, rowvals = possible_values
     with open(output_path, 'wb') as f:
         writer = csv.writer(f)
@@ -74,26 +74,26 @@ def convert_txt_align(input_path, output_path=None, invert=False):
         basename, ext = path.splitext(fname)
         assert basename.startswith('al_regr_')
         output_path = path.join(fpath, "al_%s.csv" % basename[8:])
-    print "converting '%s' to '%s'" % (input_path, output_path)
+    print("converting '%s' to '%s'" % (input_path, output_path))
     try:
         variables, possible_values, data = load_txt_align(input_path, invert)
         save_csv_align(output_path, variables, possible_values, data)
     except Exception:
-        print "FAILED"
-    
+        print("FAILED")
+
 if __name__ == '__main__':
     args = sys.argv
     if len(args) < 2:
-        print "Usage: %s [input_path] [output_path] [invert]" % args[0]
+        print("Usage: %s [input_path] [output_path] [invert]" % args[0])
         sys.exit()
     else:
         input_path = args[1]
 
     if len(args) < 3:
         output_path = None
-    else: 
+    else:
         output_path = args[2]
 
     invert = len(args) >= 4 and args[3] == 'invert'
-    
+
     convert_txt_align(input_path, output_path, invert)

--- a/tools/objtype2alive.py
+++ b/tools/objtype2alive.py
@@ -4,22 +4,22 @@ from data_main import load_objtype, export_csv_3col
 import numpy as np
 
 if __name__ == '__main__':
-    print 'Using Python %s' % sys.version
-    
+    print('Using Python %s' % sys.version)
+
     args = sys.argv
     if len(args) < 2:
-        print "Usage: %s [entity_name]" % args[0]
+        print("Usage: %s [entity_name]" % args[0])
         sys.exit()
     else:
         ent_name = args[1]
-    
-    
+
+
     ids = load_objtype("objtype_%s.txt" % ent_name)
     dtype = np.dtype([('period', int), ('id', int), ('alive', int)])
     data = np.empty(len(ids), dtype=dtype)
     data['id'] = ids
     data['period'] = 2002
-    data['alive'] = 1 
-    
+    data['alive'] = 1
+
     export_csv_3col("%s_co_alive.txt" % ent_name, data, 'alive', "\t")
-    print "done"
+    print("done")


### PR DESCRIPTION
Some print statements make tets fails on python 3.7 so I migrated all the print statements to functions.